### PR TITLE
impl coalesce function

### DIFF
--- a/lynx/src/main/scala/org/grapheco/lynx/procedure/functions/ScalarFunctions.scala
+++ b/lynx/src/main/scala/org/grapheco/lynx/procedure/functions/ScalarFunctions.scala
@@ -20,6 +20,16 @@ class ScalarFunctions {
   val booleanPattern = Pattern.compile("true|false", Pattern.CASE_INSENSITIVE)
   val numberPattern = Pattern.compile("-?[0-9]+.?[0-9]*")
 
+  /**
+    *returns the first non-null value in the given list of expressions.
+    * @param args
+    */
+  @LynxProcedure(name = "coalesce")
+  def coalesce(args: Seq[LynxValue]): LynxValue = {
+    val res = args.find(p => p != LynxNull)
+    res.getOrElse(LynxNull)
+  }
+
   /** Returns the first element in a list.
     * Considerations:
     * - head(null) returns null.

--- a/lynx/src/test/main/scala/org/grapheco/lynx/CallTest.scala
+++ b/lynx/src/test/main/scala/org/grapheco/lynx/CallTest.scala
@@ -35,6 +35,16 @@ class CallTest extends TestBase {
   }
 
   @Test
+  def coalesceTest(): Unit = {
+    runOnDemoGraph("create (n:Developer{name:'Alice2', age: 38, eyes: 'brown'})")
+    val r = runOnDemoGraph(
+      "match (n) where n.name='Alice2' return coalesce(n.hairColor, n.eyes) as value"
+    ).records()
+    val res = r.next()("value")
+    Assert.assertEquals("brown", res.value)
+  }
+
+  @Test
   def testWrongCall(): Unit = {
     Assert.assertThrows(classOf[UnknownProcedureException], new ThrowingRunnable() {
       override def run(): Unit = {


### PR DESCRIPTION
### What changes were proposed in this pull request?
impl user-define function `coalesce ` #85 


### Why are the changes needed?
for #12 


### Does this PR introduce _any_ user-facing change?
user can use coalesce in cypher: `match (n) where n.name='Alice' return coalesce(n.hairColor, n.eyes) as value`


### How was this patch tested?
run passed in CallTest of Lynx
