### PR TITLE
[TuDB-134][bug] Serialize output columns in the correct order.

### DIFF
--- a/server/src/test/scala/org.grapheco/tudb/test/server/JsonTest.scala
+++ b/server/src/test/scala/org.grapheco/tudb/test/server/JsonTest.scala
@@ -68,8 +68,9 @@ class JsonTest {
     }
     val json5 = resutlData.toJson()
     println(json5)
-    Assert.assertTrue(
-      json5 == """[[{"keys": ["a"],"length": 1,"_fields":["1"]},{"keys": ["b"],"length": 1,"_fields":["2"]}]]"""
+    Assert.assertEquals(
+      """[[{"keys": ["a"],"length": 1,"_fields":["1"]},{"keys": ["b"],"length": 1,"_fields":["2"]}]]""",
+      json5
     )
 
     /**  one-hop test


### PR DESCRIPTION
<!--
Thanks for sending a pull request!  Here are some tips for you:
  1. If this is your first time, please read our contributor guidelines:
  2. Ensure you have added or run the appropriate tests for your PR:
  3. If the PR is unfinished, add '[WIP]' in your PR title, e.g., '[WIP] Your PR title ...'.
  4. Be sure to keep the PR description updated to reflect all changes.
  5. Please write your PR title to summarize what this PR proposes.
  6. If possible, provide a concise example to reproduce the issue for a faster review.
-->

### What changes were proposed in this pull request?
Respect output column order when serializing query result. 


### Why are the changes needed?
<!--
Please clarify why the changes are needed. For instance,
  1. If you propose a new API, clarify the use case for a new API.
  2. If you fix a bug, you can clarify why it is a bug.
-->
Correctness: output column order is part of correctness (result of final projection).
Ease of testing: faithful test cannot be guaranteed without stable output column order.

### Does this PR introduce _any_ user-facing change?
<!--
Note that it means *any* user-facing change including all aspects such as the documentation fix.
If yes, please clarify the previous behavior and the change this PR proposes - provide the console output, description and/or an example to show the behavior difference if possible.
If no, write 'No'.
-->
No


### How was this patch tested?
<!--
If tests were added, say they were added here. Please make sure to add some test cases that check the changes thoroughly including negative and positive cases if possible.
If it was tested in a way different from regular unit tests, please clarify how you tested step by step, ideally copy and paste-able, so that other reviewers can test and check, and descendants can verify in the future.
If tests were not added, please describe why they were not added and/or why it was difficult to add.
-->
Change is covered by existing json Ser/De tests.
Passed `mvn -B clean install test --file pom.xml`
