### PR TITLE
ci: Cancel redundant builds in the same PR

### DIFF
--- a/.github/workflows/maven.yml
+++ b/.github/workflows/maven.yml
@@ -8,7 +8,11 @@ on:
     branches: [ main, dev ]
   pull_request:
     branches: [ main, dev ]
-      
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
 jobs:
   build:
     runs-on: self-hosted

--- a/.github/workflows/pre-commit.yml
+++ b/.github/workflows/pre-commit.yml
@@ -6,6 +6,10 @@ on:
   pull_request:
     branches: [ main, dev ]
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
 jobs:
   pre-commit:
     runs-on: self-hosted


### PR DESCRIPTION
This would save us some computational resources.

Signed-off-by: Yuan Tang <terrytangyuan@gmail.com>
