### PR TITLE
Make function name in registry case insensitive

### DIFF
--- a/lynx/src/main/scala/org/grapheco/lynx/procedure/DefaultProcedureRegistry.scala
+++ b/lynx/src/main/scala/org/grapheco/lynx/procedure/DefaultProcedureRegistry.scala
@@ -44,7 +44,7 @@ class DefaultProcedureRegistry(types: TypeSystem, classes: Class[_]*)
   }
 
   def register(name: String, procedure: CallableProcedure): Unit = {
-    procedures(name) = procedure
+    procedures(name.toLowerCase) = procedure
     logger.debug(s"registered procedure: ${procedure.signature(name)}")
   }
 
@@ -65,5 +65,5 @@ class DefaultProcedureRegistry(types: TypeSystem, classes: Class[_]*)
   }
 
   override def getProcedure(prefix: List[String], name: String): Option[CallableProcedure] =
-    procedures.get((prefix :+ name).mkString("."))
+    procedures.get((prefix :+ name).mkString(".").toLowerCase)
 }

--- a/lynx/src/test/main/scala/org/grapheco/lynx/CallTest.scala
+++ b/lynx/src/test/main/scala/org/grapheco/lynx/CallTest.scala
@@ -484,8 +484,11 @@ class CallTest extends TestBase {
 
   @Test
   def testCaseInsensitiveFunctionName(): Unit = {
-    Assert.assertThrows(classOf[ProcedureUnregisteredException], new ThrowingRunnable() {
-      override def run(): Unit = runOnDemoGraph("Match p = ()-->()-->() return LENGTH(p) as length;")
-    })
+    Assert.assertEquals(
+      LynxInteger(2),
+      runOnDemoGraph("Match p = ()-->()-->() return LENGTH(p) as length;")
+        .records()
+        .next()("length")
+    )
   }
 }


### PR DESCRIPTION




### What changes were proposed in this pull request?
<!--
Please clarify what changes you are proposing. The purpose of this section is to outline the changes and how this PR fixes the issue.
If possible, please consider writing useful notes for better and faster reviews in your PR.
-->
Make function name in registry case insensitive

### Why are the changes needed?
Fixing #141. Currently we reigster/lookup a function in register in a case-sensitive manner. This can cause error when query use function name of different letter case.


### Does this PR introduce _any_ user-facing change?
<!--
Note that it means *any* user-facing change including all aspects such as the documentation fix.
If yes, please clarify the previous behavior and the change this PR proposes - provide the console output, description and/or an example to show the behavior difference if possible.
If no, write 'No'.
-->
Yes. Function name in function call will be case-insensitive.

### How was this patch tested?
<!--
If tests were added, say they were added here. Please make sure to add some test cases that check the changes thoroughly including negative and positive cases if possible.
If it was tested in a way different from regular unit tests, please clarify how you tested step by step, ideally copy and paste-able, so that other reviewers can test and check, and descendants can verify in the future.
If tests were not added, please describe why they were not added and/or why it was difficult to add.
-->
mvn clean install test
