### PR TITLE
update: rename getHighPerConfig to getHighPerformanceConfig

### DIFF
--- a/storage/src/main/scala/org/grapheco/tudb/store/storage/RocksDBStorage.scala
+++ b/storage/src/main/scala/org/grapheco/tudb/store/storage/RocksDBStorage.scala
@@ -43,7 +43,7 @@ object RocksDBStorage extends LazyLogging {
 
       try {
         new RocksDBStorage(
-          RocksDB.open(RocksDBStorageConfig.getHighPerConfig(createIfMissing), path)
+          RocksDB.open(RocksDBStorageConfig.getHighPerformanceConfig(createIfMissing), path)
         )
       } catch {
         case ex: Exception =>

--- a/storage/src/main/scala/org/grapheco/tudb/store/storage/RocksDBStorageConfig.scala
+++ b/storage/src/main/scala/org/grapheco/tudb/store/storage/RocksDBStorageConfig.scala
@@ -62,7 +62,7 @@ object RocksDBStorageConfig {
     * @param createIfMissing
     * @return
     */
-  def getHighPerConfig(createIfMissing: Boolean): Options = {
+  def getHighPerformanceConfig(createIfMissing: Boolean): Options = {
     val options: Options = new Options()
     val tableConfig = new BlockBasedTableConfig()
 


### PR DESCRIPTION

### What changes were proposed in this pull request?

Rename from `getHighPerConfig` to `getHighPerformanceConfig`


### Why are the changes needed?

Better name to avoid confusion

### Does this PR introduce _any_ user-facing change?

No

### How was this patch tested?

mvn compile package