### PR TITLE
ci: Change dependabot PRs to China morning time

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -16,3 +16,4 @@ updates:
       day: "monday"
       time: "10:00"
       timezone: "Asia/Shanghai"
+    open-pull-requests-limit: 5


### PR DESCRIPTION
The default time is quite earlier especially for folks in China.