### PR TITLE
fix: Wait for channel to shutdown properly

### DIFF
--- a/client/src/main/scala/org/grapheco/tudb/client/GraphAPIClient.scala
+++ b/client/src/main/scala/org/grapheco/tudb/client/GraphAPIClient.scala
@@ -21,7 +21,8 @@ class GraphAPIClient(host: String, port: Int) extends LazyLogging {
   } catch {
     case _: Throwable =>
       if (channel != null) {
-        channel.shutdown().awaitTermination(5, TimeUnit.SECONDS)
+        channel.shutdown()
+        while (!channel.awaitTermination(5, TimeUnit.SECONDS)) {}
       }
   }
 

--- a/client/src/main/scala/org/grapheco/tudb/client/TuDBClient.scala
+++ b/client/src/main/scala/org/grapheco/tudb/client/TuDBClient.scala
@@ -25,7 +25,8 @@ class TuDBClient(host: String, port: Int) {
   } catch {
     case _: Throwable =>
       if (channel != null) {
-        channel.shutdown().awaitTermination(5, TimeUnit.SECONDS)
+        channel.shutdown()
+        while (!channel.awaitTermination(5, TimeUnit.SECONDS)) {}
       }
   }
 


### PR DESCRIPTION
This fixes random failures in the CI:
```
2022-08-23T14:50:04.2214951Z SEVERE: *~*~*~ Channel ManagedChannelImpl{logId=36, target=127.0.0.1:7601} was not shutdown properly!!! ~*~*~*
2022-08-23T14:50:04.2216351Z java.lang.RuntimeException: ManagedChannel allocation site
2022-08-23T14:50:04.2217177Z 	at io.grpc.internal.ManagedChannelOrphanWrapper$ManagedChannelReference.<init>(ManagedChannelOrphanWrapper.java:93)
2022-08-23T14:50:04.2218168Z 	at io.grpc.internal.ManagedChannelOrphanWrapper.<init>(ManagedChannelOrphanWrapper.java:53)
2022-08-23T14:50:04.2219094Z 	at io.grpc.internal.ManagedChannelOrphanWrapper.<init>(ManagedChannelOrphanWrapper.java:44)
2022-08-23T14:50:04.2220138Z 	at io.grpc.internal.ManagedChannelImplBuilder.build(ManagedChannelImplBuilder.java:630)
2022-08-23T14:50:04.2221133Z 	at io.grpc.internal.AbstractManagedChannelImplBuilder.build(AbstractManagedChannelImplBuilder.java:297)
2022-08-23T14:50:04.2222014Z 	at org.grapheco.tudb.client.TuDBClient.<init>(TuDBClient.scala:23)
```


Signed-off-by: Yuan Tang <terrytangyuan@gmail.com>
