### PR TITLE
fix multiple path scan bug

### DIFF
--- a/lynx/src/main/scala/org/grapheco/lynx/execution/PathScanOperator.scala
+++ b/lynx/src/main/scala/org/grapheco/lynx/execution/PathScanOperator.scala
@@ -144,7 +144,7 @@ case class PathScanOperator(
           .grouped(numRowsPerBatch)
           .map(batch =>
             batch.map(pathTriple =>
-              Seq(pathTriple.head.startNode, LynxPath(pathTriple), pathTriple.head.endNode)
+              Seq(pathTriple.head.startNode, LynxPath(pathTriple), pathTriple.last.endNode)
             )
           )
           .map(f => RowBatch(f))


### PR DESCRIPTION
### What changes were proposed in this pull request?
like `(a)-[r*1..3]->(b)`, we should filter first path's head node and last path's last node, rather than first path's head node and first path's last node.  

### Why are the changes needed?
as shown above

### Does this PR introduce _any_ user-facing change?
No.

### How was this patch tested?
No.
