### PR TITLE
Fix wrong expect result of Join test

### DIFF
--- a/lynx/src/test/main/scala/org/grapheco/lynx/CypherJoinTest.scala
+++ b/lynx/src/test/main/scala/org/grapheco/lynx/CypherJoinTest.scala
@@ -36,7 +36,7 @@ class CypherJoinTest extends TestBase {
     RETURN count(a)""".stripMargin
     val rs = runOnDemoGraph(q).records().toSeq.head
     val a = rs.get("count(a)").get.asInstanceOf[LynxInteger]
-    Assert.assertEquals(2, a.value)
+    Assert.assertEquals(4, a.value)
   }
 
   @Test


### PR DESCRIPTION
### What changes were proposed in this pull request?
as title 

### Why are the changes needed?
For historical reason, the expect test result is not correct. （verified on neo4j）

### Does this PR introduce _any_ user-facing change?
No

### How was this patch tested?
tested.
