### PR TITLE
Fixed logical errors in the default method of expand path

### DIFF
--- a/lynx/src/main/scala/org/grapheco/lynx/graph/GraphModel.scala
+++ b/lynx/src/main/scala/org/grapheco/lynx/graph/GraphModel.scala
@@ -280,10 +280,10 @@ trait GraphModel {
                 endNodeFilter.matches(pathTriple.startNode) || endNodeFilter.matches(
                   pathTriple.endNode
                 )
-              )
+              ) &&
+              pathTriple.endNode != node
         }
       }
-      .filter(p => p.endNode != node)
       .map(Seq(_))
   }
 

--- a/lynx/src/main/scala/org/grapheco/lynx/graph/GraphModel.scala
+++ b/lynx/src/main/scala/org/grapheco/lynx/graph/GraphModel.scala
@@ -243,7 +243,7 @@ trait GraphModel {
         relationships()
           .flatMap(item => Seq(item, item.revert))
           .filter(r => r.startNode.id == node.id || r.endNode.id == node.id)
-      case INCOMING => relationships().map(_.revert).filter(_.endNode.id == node.id)
+      case INCOMING => relationships().map(_.revert).filter(_.startNode.id == node.id)
       case OUTGOING => relationships().filter(_.startNode.id == node.id)
     }
   }
@@ -283,6 +283,7 @@ trait GraphModel {
               )
         }
       }
+      .filter(p => p.endNode != node)
       .map(Seq(_))
   }
 

--- a/lynx/src/test/main/scala/org/grapheco/lynx/CypherQueryTest.scala
+++ b/lynx/src/test/main/scala/org/grapheco/lynx/CypherQueryTest.scala
@@ -27,7 +27,7 @@ class CypherQueryTest extends TestBase {
       |(c{name:"CNIC", age: 10}),
       |(a)-[:knows]->(b),
       |(b)-[:knows]->(c),
-      |(a)-[]->(c)
+      |(a)-[:knows]->(c)
       |""".stripMargin)
   @Test
   def testQueryUnit(): Unit = {
@@ -202,12 +202,12 @@ class CypherQueryTest extends TestBase {
   }
 
   @Test
-  def testQueryMultipleMatchs(): Unit = {
+  def testQueryMultipleMatches(): Unit = {
     var rs = runOnDemoGraph("match ()-[r]-(n) match (n)-[s]-() return r,s")
-    Assert.assertEquals(6, rs.records.size)
+    Assert.assertEquals(12, rs.records.size)
 
     rs = runOnDemoGraph("match ()-[r]->(n) match (n)-[s]-() return r,s")
-    Assert.assertEquals(3, rs.records.size)
+    Assert.assertEquals(6, rs.records.size)
 
     rs = runOnDemoGraph("match (m)-[r]->(n) match (n)-[s]->(x) return r,s")
     Assert.assertEquals(1, rs.records.size)


### PR DESCRIPTION
### What changes were proposed in this pull request?
1. Fix wrong expect results (verified on Neo4j).

2. Create relationship must specify relationship type.

3. Incoming direction reverse the pathTriple's start node and end node, so expand path should filter the start node.

4.  Both directions should determine whether the last node of the previous path and the last node of the next path are not equal, because they have a redundant relationship. For example: `match (a)-[r]-(b)`, we will get `(a)-[r]-(b)` and `(b)-[r]-(a)`, so patten like: `match (a)-[r1]-(b)-[r2]-(c)`, we will first query relationship `(a)-[r1]-(b)`, then expand from b. Expand from b we will get `(b)-[r2]-(c)` or `(c)-[r2]-(b)`, finally we will get `(a)-[r1]-(b)-[r2]-(c)` or `(a)-[r1]-(b)-[r2]-(b)`.

### Why are the changes needed?
as title


### Does this PR introduce _any_ user-facing change?
No

### How was this patch tested?
test passed.
